### PR TITLE
Add line axis theme

### DIFF
--- a/src/Axis.tsx
+++ b/src/Axis.tsx
@@ -6,7 +6,7 @@ import { useTimelineTheme } from './theme'
 
 const useAxisStyles = makeStyles((theme: Theme) => ({
   axis: (lineAxisTheme: LineAxisTheme) => ({
-    stroke: lineAxisTheme.stroke ? lineAxisTheme.stroke : theme.palette.grey['500'],
+    stroke: lineAxisTheme.strokeColor ? lineAxisTheme.strokeColor : theme.palette.grey['500'],
     strokeWidth: lineAxisTheme.strokeWidth ? lineAxisTheme.strokeWidth : 2,
   }),
 }))

--- a/src/theme/model.ts
+++ b/src/theme/model.ts
@@ -27,6 +27,6 @@ export interface TrimmerTheme {
 }
 
 export interface LineAxisTheme {
-  readonly stroke?: string
+  readonly strokeColor?: string
   readonly strokeWidth?: number
 }


### PR DESCRIPTION
Adds a line axis theme so that we can customize the stoke color and stroke width of the timeline's horizontal line axis 

before
<img width="1519" alt="Screen Shot 2021-10-28 at 8 05 14 PM" src="https://user-images.githubusercontent.com/39421794/139352584-1ee6933b-cb9d-4c69-a207-7c6ee5923b6b.png">

after
<img width="1519" alt="Screen Shot 2021-10-28 at 8 04 46 PM" src="https://user-images.githubusercontent.com/39421794/139352602-4dc25bcd-b1c4-435f-9b6b-c3bbde1b86e7.png">

