### PR TITLE
Add a tooltip arrow prop

### DIFF
--- a/src/CollapsedMarks.tsx
+++ b/src/CollapsedMarks.tsx
@@ -14,12 +14,23 @@ interface Props<EID extends string, LID extends string, E extends TimelineEvent<
   onEventHover?: (eventId: EID) => void
   onEventUnhover?: (eventId: EID) => void
   onEventClick?: (eventId: EID) => void
+  tooltipArrow?: boolean
 }
 
 export const CollapsedMarks = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>(
   props: Props<EID, LID, E>
 ) => {
-  const { mouseCursor, height, events, timeScale, eventComponent, onEventHover, onEventUnhover, onEventClick } = props
+  const {
+    mouseCursor,
+    height,
+    events,
+    timeScale,
+    eventComponent,
+    onEventHover,
+    onEventUnhover,
+    onEventClick,
+    tooltipArrow,
+  } = props
   const y = height / 2
 
   return (
@@ -36,6 +47,7 @@ export const CollapsedMarks = <EID extends string, LID extends string, E extends
           onEventHover={onEventHover}
           onEventUnhover={onEventUnhover}
           onEventClick={onEventClick}
+          tooltipArrow={tooltipArrow}
         />
       }
     </g>

--- a/src/ExpandedMarks.tsx
+++ b/src/ExpandedMarks.tsx
@@ -29,6 +29,7 @@ interface Props<EID extends string, LID extends string, E extends TimelineEvent<
   onEventHover?: (eventId: EID) => void
   onEventUnhover?: (eventId: EID) => void
   onEventClick?: (eventId: EID) => void
+  tooltipArrow?: boolean
 }
 
 export const ExpandedMarks = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>({
@@ -42,6 +43,7 @@ export const ExpandedMarks = <EID extends string, LID extends string, E extends 
   onEventHover,
   onEventUnhover,
   onEventClick,
+  tooltipArrow,
 }: Props<EID, LID, E>) => {
   const classes = useStyles()
   const fontSize = 0.8 * yScale.bandwidth()
@@ -79,6 +81,7 @@ export const ExpandedMarks = <EID extends string, LID extends string, E extends 
           onEventHover={onEventHover}
           onEventUnhover={onEventUnhover}
           onEventClick={onEventClick}
+          tooltipArrow={tooltipArrow}
         />
       </g>
     )

--- a/src/Marks.tsx
+++ b/src/Marks.tsx
@@ -41,6 +41,7 @@ export interface Props<EID extends string, LID extends string, E extends Timelin
   onEventHover?: (eventId: EID) => void
   onEventUnhover?: (eventId: EID) => void
   onEventClick?: (eventId: EID) => void
+  tooltipArrow?: boolean
 }
 
 /**
@@ -146,6 +147,7 @@ interface InteractiveGroupProps<EID extends string, LID extends string, E extend
   onEventClick?: (eventId: EID) => void
   tooltipClasses: TooltipClasses
   children: React.ReactNode
+  tooltipArrow?: boolean
 }
 
 const InteractiveEventMark = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>({
@@ -157,6 +159,7 @@ const InteractiveEventMark = <EID extends string, LID extends string, E extends 
   onEventUnhover = noOp,
   tooltipClasses,
   children,
+  tooltipArrow,
 }: InteractiveGroupProps<EID, LID, E>) => {
   const eventId = event.eventId
 
@@ -187,6 +190,7 @@ const InteractiveEventMark = <EID extends string, LID extends string, E extends 
           triggerRef={triggerRef}
           text={event.tooltip}
           classes={tooltipClasses}
+          tooltipArrow={tooltipArrow}
         />
       ) : (
         <g />

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -40,6 +40,7 @@ export interface TimelineProps<EID extends string, LID extends string, E extends
   onInteractionEnd?: () => void
   weekStripes?: boolean
   cursorColor?: string
+  tooltipArrow?: boolean
 }
 
 type Animation =
@@ -84,6 +85,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
   onInteractionEnd,
   weekStripes,
   cursorColor,
+  tooltipArrow = true,
 }: TimelineProps<EID, LID, E>) => {
   {
     const maxDomain = customRange ?? calcMaxDomain(events)
@@ -307,6 +309,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
                               onEventHover={onEventHoverDecorated}
                               onEventUnhover={onEventUnhoverDecorated}
                               onEventClick={onEventClick}
+                              tooltipArrow={tooltipArrow}
                             />
                           ) : (
                             <CollapsedMarks
@@ -318,6 +321,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
                               onEventHover={onEventHoverDecorated}
                               onEventUnhover={onEventUnhoverDecorated}
                               onEventClick={onEventClick}
+                              tooltipArrow={tooltipArrow}
                             />
                           )}
                         </>

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -11,9 +11,10 @@ interface Props {
   readonly text: string
   readonly triggerRef: React.RefObject<SVGElement>
   readonly classes: TooltipClasses
+  readonly tooltipArrow?: boolean
 }
 
-export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes }: Props) => {
+export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, tooltipArrow }: Props) => {
   const { textLines, tooltipWidth, tooltipHeight, baseHeight } = getTooltipDimensions(text)
 
   return (
@@ -31,12 +32,14 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes }
 
         // determines how the rectangular tooltip area is offset to the left/right of the arrow
         // the closer to the left edge, the more the rect is shifted to the right (same for right edge)
-        const safetyMargin = 15
+        // if the arrow prop is falsy, safety margin is 0
+        const safetyMargin = tooltipArrow ? 15 : 0
         const tooltipOffset = scaleLinear()
           .domain([0, parentWidth])
           .range([safetyMargin, tooltipWidth - safetyMargin])
 
-        const arrowDimension = 20
+        // if prop value is falsy, reduce the number so that the tooltip is closer to the event mark
+        const arrowDimension = tooltipArrow ? 20 : 10
 
         const svgX = tooltipX - tooltipOffset(xOffset)!
         const svgY = tooltipY - arrowDimension / 2
@@ -52,7 +55,9 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes }
                 className={classes.text}
               />
             </svg>
-            <ArrowDown tipX={tooltipX} baseY={baseY} dimension={arrowDimension} className={classes.background} />)
+            {tooltipArrow && (
+              <ArrowDown tipX={tooltipX} baseY={baseY} dimension={arrowDimension} className={classes.background} />
+            )}
           </g>
         )
       }}


### PR DESCRIPTION
figma designs don't have an arrow on the tooltip so I added a prop so that we can disable it. 

unfortunately requires prop drilling but since designs may change and we may want the the arrow in the future, thought it'd be better for it to be a prop than hard code removal of the arrow.

Default
![default](https://user-images.githubusercontent.com/39421794/139473778-2e15760f-3f1d-4e6d-a633-fd8f99141bee.gif)

when prop is falsy
![noarrow](https://user-images.githubusercontent.com/39421794/139473871-9d0c895a-5555-4eed-809a-6f52e748d6d8.gif)


