### PR TITLE
add prop to customize rx and ry of tooltip

### DIFF
--- a/src/theme/model.ts
+++ b/src/theme/model.ts
@@ -18,6 +18,8 @@ export interface TooltipTheme {
   readonly strokeColor?: string
   readonly strokeWidth?: number
   readonly fontColor?: string
+  readonly rx?: number
+  readonly ry?: number
 }
 
 export interface TrimmerTheme {

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -47,7 +47,7 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
         return (
           <g>
             <svg x={svgX} y={svgY} width={tooltipWidth} height={tooltipHeight} className={classes.svg}>
-              <rect width="100%" height="100%" rx={3} ry={3} className={classes.background} />
+              <rect width="100%" height="100%" className={classes.background} />
               <TooltipText
                 textLines={textLines}
                 tooltipHeight={tooltipHeight}

--- a/src/tooltip/useTooltipStyle.ts
+++ b/src/tooltip/useTooltipStyle.ts
@@ -15,6 +15,8 @@ export const useTooltipStyle = makeStyles((theme: Theme) => ({
     fill: tooltipTheme.backgroundColor,
     strokeWidth: tooltipTheme.strokeWidth ? tooltipTheme.strokeWidth : 0,
     stroke: tooltipTheme.strokeColor ? tooltipTheme.strokeColor : 'transparent',
+    rx: tooltipTheme.rx ? tooltipTheme.rx : 3,
+    ry: tooltipTheme.ry ? tooltipTheme.ry : 3,
   }),
   text: (tooltipTheme: TooltipTheme) => ({
     fill: tooltipTheme.fontColor ? tooltipTheme.fontColor : 'white',


### PR DESCRIPTION
this will allow us to add rounded corners to the tooltip

before
<img width="506" alt="Screen Shot 2021-11-01 at 10 02 32 AM" src="https://user-images.githubusercontent.com/39421794/139684163-4c4b10e6-fb47-44d6-aaa5-ff1815f00661.png">

after
<img width="506" alt="Screen Shot 2021-11-01 at 10 03 04 AM" src="https://user-images.githubusercontent.com/39421794/139684181-f7cf3b1b-2d3a-4516-af4a-14acfb4f2f78.png">