### PR TITLE
Move tooltip y position to be below rather than above icons

### DIFF
--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -28,9 +28,17 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
 
         const tooltipYPadding = 12
         //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
-        const tooltipY = y + yOffset - baseHeight - tooltipYPadding;;
+        const tooltipY = y + yOffset - tooltipHeight - tooltipYPadding;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
+
+        console.log("tooltipY " + tooltipY);
+        console.log("y " + y);
+        console.log("yOffset " + yOffset);
+        console.log("tooltipHeight " + tooltipHeight);
+        console.log("tooltipYPadding " + tooltipYPadding);
+        console.log("baseHeight " + baseHeight);
+        console.log("baseY " + baseY);
         // determines how the rectangular tooltip area is offset to the left/right of the arrow
         // the closer to the left edge, the more the rect is shifted to the right (same for right edge)
         // if the arrow prop is falsy, safety margin is 0

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -27,18 +27,9 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
         const tooltipX = type === 'period' ? 0 : type.singleEventX - xOffset
 
         const tooltipYPadding = 12
-        //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
         const tooltipY = y - yOffset + tooltipHeight - tooltipYPadding;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
-
-        console.log("tooltipY " + tooltipY);
-        console.log("y " + y);
-        console.log("yOffset " + yOffset);
-        console.log("tooltipHeight " + tooltipHeight);
-        console.log("tooltipYPadding " + tooltipYPadding);
-        console.log("baseHeight " + baseHeight);
-        console.log("baseY " + baseY);
         // determines how the rectangular tooltip area is offset to the left/right of the arrow
         // the closer to the left edge, the more the rect is shifted to the right (same for right edge)
         // if the arrow prop is falsy, safety margin is 0

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -28,7 +28,7 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
 
         const tooltipYPadding = 12
         //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
-        const tooltipY = y - yOffset + tooltipHeight + tooltipYPadding;
+        const tooltipY = y - yOffset + tooltipHeight - tooltipYPadding;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
 

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -28,7 +28,7 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
 
         const tooltipYPadding = 12
         //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
-        const tooltipY = y - yOffset - tooltipHeight + tooltipYPadding;
+        const tooltipY = y - yOffset + tooltipHeight + tooltipYPadding;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
 

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -28,7 +28,7 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
 
         const tooltipYPadding = 12
         //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
-        const tooltipY = y;
+        const tooltipY = y + yOffset - baseHeight - tooltipYPadding;;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
         // determines how the rectangular tooltip area is offset to the left/right of the arrow

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -27,7 +27,8 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
         const tooltipX = type === 'period' ? 0 : type.singleEventX - xOffset
 
         const tooltipYPadding = 12
-        const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
+        //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
+        const tooltipY = y;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
         // determines how the rectangular tooltip area is offset to the left/right of the arrow

--- a/src/tooltip/EventTooltip.tsx
+++ b/src/tooltip/EventTooltip.tsx
@@ -28,7 +28,7 @@ export const EventTooltip = ({ type, y, parentWidth, text, triggerRef, classes, 
 
         const tooltipYPadding = 12
         //const tooltipY = y - yOffset - tooltipHeight - tooltipYPadding // don't follow mouse
-        const tooltipY = y + yOffset - tooltipHeight - tooltipYPadding;
+        const tooltipY = y - yOffset - tooltipHeight + tooltipYPadding;
         const baseY = y - yOffset - baseHeight - tooltipYPadding
 
 


### PR DESCRIPTION
There are many options and it is kind of wonky because it is not as simple as just using react-tooltip and specifying the `place`. However I think this looks decent
before:
<img width="498" alt="Screen Shot 2021-11-03 at 7 43 17 AM" src="https://user-images.githubusercontent.com/66325812/140082893-0499638e-e371-407f-9a69-4d162821d0e5.png">
after:
<img width="551" alt="Screen Shot 2021-11-03 at 7 39 23 AM" src="https://user-images.githubusercontent.com/66325812/140082898-c6809c08-f14b-4705-ae16-9156ee3f3db0.png">
.
