### PR TITLE
start and end timestamps

### DIFF
--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -271,7 +271,8 @@ const useHourViewStyles = makeStyles((theme: Theme) => ({
 
 const getTimelineBoundsLabel = (date: Date) => {
   const time = date.toLocaleTimeString();
-  const month = date.getMonth();
+  // +1 because months start at 0
+  const month = date.getMonth() + 1;
   const day = date.getDate();
   const label = `${month}/${day} @ ${time}`;
   return label;
@@ -291,16 +292,13 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const leftBoundPos = timeScale(leftBoundMs)!
   const rightBoundPos = timeScale(rightBoundMs)!
 
-  // TODO: What should I use as the key? Does it matter? 
-  //UPDATE: If key value is something based of time (like date.getMilliseconds) then there are serious rendering issues
+  // TODO: Possibly change key
   const lines = [
       (<g key={1}>
-        {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
         <HourLine xPosition={leftBoundPos} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
           {leftBoundLabel}
         </text>
-        {/* TODO: add day? Requires logic */}
       </g>),
       (<g key={2}>
         <HourLine xPosition={rightBoundPos} />

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -257,10 +257,6 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useMonthViewStyles(xAxisTheme)
 
-  console.log("why are there 3 lines?????????????????")
-  console.log(new Date(domain?.[0]).toLocaleTimeString);
-  console.log(new Date(domain?.[1]).toLocaleTimeString);
-
   // Scale the bounds slightly inside so they don't touch the edges
   const leftBoundMs = domain[0] + SECOND_OFFSET_MS;
   const rightBoundMs = domain[1] - SECOND_OFFSET_MS;
@@ -277,14 +273,14 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
         {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
         <HourLine xPosition={leftBoundPos} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
-          {leftBoundDate.toTimeString()}
+          {leftBoundDate.toLocaleTimeString()}
         </text>
         {/* TODO: add day? Requires logic */}
       </g>),
       (<g key={2}>
         <HourLine xPosition={rightBoundPos} />
         <text className={classes.label} x={rightBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
-          {rightBoundDate.toTimeString()}
+          {rightBoundDate.toLocaleTimeString()}
         </text>
       </g>)
   ];

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -253,7 +253,6 @@ interface HourViewProps {
   timeScale: ScaleLinear<number, number>
 }
 
-// TODO(smonero): move all these to config
 const defaultHourViewLabelFontSize = 10
 
 const useHourViewStyles = makeStyles((theme: Theme) => ({
@@ -262,8 +261,8 @@ const useHourViewStyles = makeStyles((theme: Theme) => ({
     fill: xAxisTheme.labelColor,
     opacity: 0.5,
     fontFamily: theme.typography.caption.fontFamily,
-    fontSize: defaultHourViewLabelFontSize,
-    fontWeight: xAxisTheme.monthLabelFontWeight ? xAxisTheme.monthLabelFontWeight : 'bold',
+    fontSize: xAxisTheme.hourLabelFontSize ? xAxisTheme.hourLabelFontSize : defaultHourViewLabelFontSize,
+    fontWeight: xAxisTheme.hourLabelFontWeight ? xAxisTheme.hourLabelFontWeight : 'bold',
     textAnchor: 'middle',
     cursor: 'default',
   }),
@@ -296,13 +295,13 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const lines = [
       (<g key={1}>
         <HourLine xPosition={leftBoundPos} />
-        <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
+        <text className={classes.label} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {leftBoundLabel}
         </text>
       </g>),
       (<g key={2}>
         <HourLine xPosition={rightBoundPos} />
-        <text className={classes.label} x={rightBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
+        <text className={classes.label} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {rightBoundLabel}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -240,7 +240,7 @@ const HourLine = ({ xPosition, height }: HourLineProps) => {
       x1={xPosition}
       y1={0}
       x2={xPosition}
-      y2={height ? height : '20%'}
+      y2={height ? height : '100%'}
       strokeWidth={1} // slightly fatter year boundary
     />
   )
@@ -279,7 +279,7 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
       </g>),
       (<g key={rightBoundDate.getMilliseconds()}>
         <HourLine xPosition={rightBoundPos} />
-        <text className={classes.label} x={rightBoundPos} y={height - 1.5 * monthViewLabelFontSize}>
+        <text className={classes.label} x={rightBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
           {rightBoundDate.toLocaleTimeString()}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -34,11 +34,10 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
       return <MonthView height={height} domain={domain} timeScale={timeScale} />
     default:
       return (
-        <MonthView
+        <HourView
           height={height}
           domain={domain}
           timeScale={timeScale}
-          showWeekStripes={weekStripes === undefined ? true : weekStripes}
         />
       )
   }
@@ -219,6 +218,72 @@ const WeekStripes = ({ monthStart, timeScale }: WeekStripesProps) => {
       return <g key={key} />
     }
   })
+
+  return <g>{lines}</g>
+}
+
+/* ·················································································································· */
+/*  Hour
+/* ·················································································································· */
+
+interface HourLineProps {
+  xPosition: number
+  height?: string
+}
+
+const HourLine = ({ xPosition, height }: HourLineProps) => {
+  const xAxisTheme = useTimelineTheme().xAxis
+  const classes = useMonthViewStyles(xAxisTheme)
+  return (
+    <line
+      className={classes.line}
+      x1={xPosition}
+      y1={0}
+      x2={xPosition}
+      y2={height ? height : '20%'}
+      strokeWidth={1} // slightly fatter year boundary
+    />
+  )
+}
+
+const MINUTE_OFFSET_MS = 60000;
+
+// TODO(smonero): I have no idea what this is for and why we are omitting smallerZoomScale
+// TODO: figure it out
+interface HourViewProps extends Omit<Props, 'smallerZoomScale'> {
+}
+
+const HourView = ({ height, domain, timeScale }: HourViewProps) => {
+  const xAxisTheme = useTimelineTheme().xAxis
+  const classes = useMonthViewStyles(xAxisTheme)
+
+  // Scale the bounds slightly inside so they don't touch the edges
+  const leftBoundMs = domain[0] + MINUTE_OFFSET_MS;
+  const rightBoundMs = domain[1] - MINUTE_OFFSET_MS;
+
+  const leftBoundDate = new Date(leftBoundMs);
+  const rightBoundDate = new Date(rightBoundMs);
+
+  const leftBoundPos = timeScale(leftBoundMs)!
+  const rightBoundPos = timeScale(rightBoundMs)!
+
+  // TODO: What should I use as the key? Does it matter?
+  const lines = [
+      (<g key={leftBoundDate.getMilliseconds}>
+        {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
+        <HourLine xPosition={leftBoundPos} />
+        <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
+          {leftBoundDate.toLocaleTimeString()}
+        </text>
+        {/* TODO: add day? Requires logic */}
+      </g>),
+      (<g key={rightBoundDate.getMilliseconds}>
+        <HourLine xPosition={rightBoundPos} />
+        <text className={classes.label} x={rightBoundPos} y={height - 1.5 * monthViewLabelFontSize}>
+          {rightBoundDate.toLocaleTimeString()}
+        </text>
+      </g>)
+  ];
 
   return <g>{lines}</g>
 }

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { ScaleLinear } from 'd3-scale'
 import { Theme } from '@material-ui/core'
-import { dayDuration, monthDuration, weekDuration, yearDuration, ZoomLevels } from './ZoomScale'
+import { monthDuration, weekDuration, yearDuration, ZoomLevels } from './ZoomScale'
 import { addMonths, addWeeks, endOfMonth, endOfWeek, isBefore, isEqual, startOfWeek } from 'date-fns'
 import { Domain } from './model'
 import makeStyles from '@material-ui/core/styles/makeStyles'

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -270,10 +270,10 @@ const useHourViewStyles = makeStyles((theme: Theme) => ({
 }))
 
 const getTimelineBoundsLabel = (date: Date) => {
-  const time = date.toTimeString();
+  const time = date.toLocaleTimeString();
   const month = date.getMonth();
   const day = date.getDay();
-  const label = `${month}-${day} @ ${time}`;
+  const label = `${month}/${day} @ ${time}`;
   return label;
 }
 

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -257,22 +257,13 @@ const defaultHourViewLabelFontSize = 10
 
 const useHourViewStyles = makeStyles((theme: Theme) => ({
   ...gridLineStyle(theme),
-  leftLabel: (xAxisTheme: XAxisTheme) => ({
+  label: (xAxisTheme: XAxisTheme) => ({
     fill: xAxisTheme.labelColor,
     opacity: 0.5,
     fontFamily: theme.typography.caption.fontFamily,
     fontSize: xAxisTheme.hourLabelFontSize ? xAxisTheme.hourLabelFontSize : defaultHourViewLabelFontSize,
     fontWeight: xAxisTheme.hourLabelFontWeight ? xAxisTheme.hourLabelFontWeight : 'bold',
-    textAnchor: 'start',
-    cursor: 'default',
-  }),
-  rightLabel: (xAxisTheme: XAxisTheme) => ({
-    fill: xAxisTheme.labelColor,
-    opacity: 0.5,
-    fontFamily: theme.typography.caption.fontFamily,
-    fontSize: xAxisTheme.hourLabelFontSize ? xAxisTheme.hourLabelFontSize : defaultHourViewLabelFontSize,
-    fontWeight: xAxisTheme.hourLabelFontWeight ? xAxisTheme.hourLabelFontWeight : 'bold',
-    textAnchor: 'end',
+    textAnchor: 'middle',
     cursor: 'default',
   }),
 }))
@@ -304,13 +295,13 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const lines = [
       (<g key={1}>
         <HourLine xPosition={leftBoundPos} />
-        <text className={classes.leftLabel} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
+        <text className={classes.label} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {leftBoundLabel}
         </text>
       </g>),
       (<g key={2}>
         <HourLine xPosition={rightBoundPos} />
-        <text className={classes.rightLabel} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
+        <text className={classes.label} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {rightBoundLabel}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -25,6 +25,7 @@ const gridLineStyle = (theme: Theme) => ({
 })
 
 export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStripes }: Props) => {
+  weekStripes = undefined;
   switch (smallerZoomScale) {
     case ZoomLevels.TEN_YEARS:
       return <YearView height={height} domain={domain} timeScale={timeScale} showDecadesOnly={true} />

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -276,14 +276,14 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
         {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
         <HourLine xPosition={leftBoundPos} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
-          {leftBoundDate.toLocaleTimeString()}
+          {leftBoundDate.toTimeString()}
         </text>
         {/* TODO: add day? Requires logic */}
       </g>),
       (<g key={rightBoundDate.getMilliseconds()}>
         <HourLine xPosition={rightBoundPos} />
         <text className={classes.label} x={rightBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
-          {rightBoundDate.toLocaleTimeString()}
+          {rightBoundDate.toTimeString()}
         </text>
       </g>)
   ];

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -246,7 +246,7 @@ const HourLine = ({ xPosition, height }: HourLineProps) => {
   )
 }
 
-const MINUTE_OFFSET_MS = 60000;
+const SECOND_OFFSET_MS = 1000;
 interface HourViewProps {
   height: number
   domain: [number, number]
@@ -258,8 +258,8 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const classes = useMonthViewStyles(xAxisTheme)
 
   // Scale the bounds slightly inside so they don't touch the edges
-  const leftBoundMs = domain[0] + MINUTE_OFFSET_MS;
-  const rightBoundMs = domain[1] - MINUTE_OFFSET_MS;
+  const leftBoundMs = domain[0] + SECOND_OFFSET_MS;
+  const rightBoundMs = domain[1] - SECOND_OFFSET_MS;
 
   const leftBoundDate = new Date(leftBoundMs);
   const rightBoundDate = new Date(rightBoundMs);

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -257,8 +257,9 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useMonthViewStyles(xAxisTheme)
 
-  console.log(domain?.[0]);
-  console.log(domain?.[1]);
+  console.log("why are there 3 lines?????????????????")
+  console.log(new Date(domain?.[0]).toLocaleTimeString);
+  console.log(new Date(domain?.[1]).toLocaleTimeString);
 
   // Scale the bounds slightly inside so they don't touch the edges
   const leftBoundMs = domain[0] + SECOND_OFFSET_MS;

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -253,8 +253,24 @@ interface HourViewProps {
   timeScale: ScaleLinear<number, number>
 }
 
+// TODO(smonero): move all these to config
+const defaultHourViewLabelFontSize = 10
+
+const useHourViewStyles = makeStyles((theme: Theme) => ({
+  ...gridLineStyle(theme),
+  label: (xAxisTheme: XAxisTheme) => ({
+    fill: xAxisTheme.labelColor,
+    opacity: 0.5,
+    fontFamily: theme.typography.caption.fontFamily,
+    fontSize: defaultHourViewLabelFontSize,
+    fontWeight: xAxisTheme.monthLabelFontWeight ? xAxisTheme.monthLabelFontWeight : 'bold',
+    textAnchor: 'middle',
+    cursor: 'default',
+  }),
+}))
+
 const getTimelineBoundsLabel = (date: Date) => {
-  const time = date.toLocaleTimeString();
+  const time = date.toTimeString();
   const month = date.getMonth();
   const day = date.getDay();
   const label = `${month}-${day} @ ${time}`;
@@ -263,7 +279,7 @@ const getTimelineBoundsLabel = (date: Date) => {
 
 const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
-  const classes = useMonthViewStyles(xAxisTheme)
+  const classes = useHourViewStyles(xAxisTheme)
 
   // Scale the bounds slightly inside so they don't touch the edges
   const leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS;

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -25,14 +25,13 @@ const gridLineStyle = (theme: Theme) => ({
 })
 
 export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStripes }: Props) => {
-  weekStripes = undefined;
   switch (smallerZoomScale) {
     case ZoomLevels.TEN_YEARS:
       return <YearView height={height} domain={domain} timeScale={timeScale} showDecadesOnly={true} />
     case ZoomLevels.ONE_YEAR:
       return <YearView height={height} domain={domain} timeScale={timeScale} />
     case ZoomLevels.ONE_MONTH:
-      return <MonthView height={height} domain={domain} timeScale={timeScale} />
+      return <MonthView height={height} domain={domain} timeScale={timeScale} showWeekStripes={weekStripes} />
     default:
       return (
         <HourView

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -246,7 +246,7 @@ const HourLine = ({ xPosition, height }: HourLineProps) => {
   )
 }
 
-const SECOND_OFFSET_MS = 1000;
+const TEN_SECOND_OFFSET_MS = 10000;
 interface HourViewProps {
   height: number
   domain: [number, number]
@@ -254,11 +254,10 @@ interface HourViewProps {
 }
 
 const getTimelineBoundsLabel = (date: Date) => {
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
+  const time = date.toLocaleTimeString();
   const month = date.getMonth();
   const day = date.getDay();
-  const label = `${month}:${day} @ ${hours}:${minutes}`;
+  const label = `${month}-${day} @ ${time}`;
   return label;
 }
 
@@ -267,8 +266,8 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const classes = useMonthViewStyles(xAxisTheme)
 
   // Scale the bounds slightly inside so they don't touch the edges
-  const leftBoundMs = domain[0] + SECOND_OFFSET_MS;
-  const rightBoundMs = domain[1] - SECOND_OFFSET_MS;
+  const leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS;
+  const rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS;
 
   const leftBoundLabel = getTimelineBoundsLabel(new Date(leftBoundMs));
   const rightBoundLabel = getTimelineBoundsLabel(new Date(rightBoundMs));
@@ -276,7 +275,8 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const leftBoundPos = timeScale(leftBoundMs)!
   const rightBoundPos = timeScale(rightBoundMs)!
 
-  // TODO: What should I use as the key? Does it matter?
+  // TODO: What should I use as the key? Does it matter? 
+  //UPDATE: If key value is something based of time (like date.getMilliseconds) then there are serious rendering issues
   const lines = [
       (<g key={1}>
         {/* TODO: maybe add stuff to HourLine like the date or time ago? */}

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -269,7 +269,7 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
 
   // TODO: What should I use as the key? Does it matter?
   const lines = [
-      (<g key={leftBoundDate.getMilliseconds}>
+      (<g key={leftBoundDate.getMilliseconds()}>
         {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
         <HourLine xPosition={leftBoundPos} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
@@ -277,7 +277,7 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
         </text>
         {/* TODO: add day? Requires logic */}
       </g>),
-      (<g key={rightBoundDate.getMilliseconds}>
+      (<g key={rightBoundDate.getMilliseconds()}>
         <HourLine xPosition={rightBoundPos} />
         <text className={classes.label} x={rightBoundPos} y={height - 1.5 * monthViewLabelFontSize}>
           {rightBoundDate.toLocaleTimeString()}

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { ScaleLinear } from 'd3-scale'
 import { Theme } from '@material-ui/core'
-import { monthDuration, weekDuration, yearDuration, ZoomLevels } from './ZoomScale'
+import { dayDuration, monthDuration, weekDuration, yearDuration, ZoomLevels } from './ZoomScale'
 import { addMonths, addWeeks, endOfMonth, endOfWeek, isBefore, isEqual, startOfWeek } from 'date-fns'
 import { Domain } from './model'
 import makeStyles from '@material-ui/core/styles/makeStyles'
@@ -253,6 +253,15 @@ interface HourViewProps {
   timeScale: ScaleLinear<number, number>
 }
 
+const getTimelineBoundsLabel = (date: Date) => {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const month = date.getMonth();
+  const day = date.getDay();
+  const label = `${month}:${day} @ ${hours}:${minutes}`;
+  return label;
+}
+
 const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useMonthViewStyles(xAxisTheme)
@@ -261,8 +270,8 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const leftBoundMs = domain[0] + SECOND_OFFSET_MS;
   const rightBoundMs = domain[1] - SECOND_OFFSET_MS;
 
-  const leftBoundDate = new Date(leftBoundMs);
-  const rightBoundDate = new Date(rightBoundMs);
+  const leftBoundLabel = getTimelineBoundsLabel(new Date(leftBoundMs));
+  const rightBoundLabel = getTimelineBoundsLabel(new Date(rightBoundMs));
 
   const leftBoundPos = timeScale(leftBoundMs)!
   const rightBoundPos = timeScale(rightBoundMs)!
@@ -273,14 +282,14 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
         {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
         <HourLine xPosition={leftBoundPos} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
-          {leftBoundDate.toLocaleTimeString()}
+          {leftBoundLabel}
         </text>
         {/* TODO: add day? Requires logic */}
       </g>),
       (<g key={2}>
         <HourLine xPosition={rightBoundPos} />
         <text className={classes.label} x={rightBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
-          {rightBoundDate.toLocaleTimeString()}
+          {rightBoundLabel}
         </text>
       </g>)
   ];

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -247,10 +247,10 @@ const HourLine = ({ xPosition, height }: HourLineProps) => {
 }
 
 const MINUTE_OFFSET_MS = 60000;
-
-// TODO(smonero): I have no idea what this is for and why we are omitting smallerZoomScale
-// TODO: figure it out
-interface HourViewProps extends Omit<Props, 'smallerZoomScale'> {
+interface HourViewProps {
+  height: number
+  domain: [number, number]
+  timeScale: ScaleLinear<number, number>
 }
 
 const HourView = ({ height, domain, timeScale }: HourViewProps) => {

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -257,13 +257,22 @@ const defaultHourViewLabelFontSize = 10
 
 const useHourViewStyles = makeStyles((theme: Theme) => ({
   ...gridLineStyle(theme),
-  label: (xAxisTheme: XAxisTheme) => ({
+  leftLabel: (xAxisTheme: XAxisTheme) => ({
     fill: xAxisTheme.labelColor,
     opacity: 0.5,
     fontFamily: theme.typography.caption.fontFamily,
     fontSize: xAxisTheme.hourLabelFontSize ? xAxisTheme.hourLabelFontSize : defaultHourViewLabelFontSize,
     fontWeight: xAxisTheme.hourLabelFontWeight ? xAxisTheme.hourLabelFontWeight : 'bold',
-    textAnchor: 'middle',
+    textAnchor: 'start',
+    cursor: 'default',
+  }),
+  rightLabel: (xAxisTheme: XAxisTheme) => ({
+    fill: xAxisTheme.labelColor,
+    opacity: 0.5,
+    fontFamily: theme.typography.caption.fontFamily,
+    fontSize: xAxisTheme.hourLabelFontSize ? xAxisTheme.hourLabelFontSize : defaultHourViewLabelFontSize,
+    fontWeight: xAxisTheme.hourLabelFontWeight ? xAxisTheme.hourLabelFontWeight : 'bold',
+    textAnchor: 'end',
     cursor: 'default',
   }),
 }))
@@ -295,13 +304,13 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const lines = [
       (<g key={1}>
         <HourLine xPosition={leftBoundPos} />
-        <text className={classes.label} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
+        <text className={classes.leftLabel} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {leftBoundLabel}
         </text>
       </g>),
       (<g key={2}>
         <HourLine xPosition={rightBoundPos} />
-        <text className={classes.label} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
+        <text className={classes.rightLabel} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {rightBoundLabel}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -240,7 +240,7 @@ const HourLine = ({ xPosition, height }: HourLineProps) => {
       x1={xPosition}
       y1={0}
       x2={xPosition}
-      y2={height ? height : '100%'}
+      y2={height ? height : '80%'}
       strokeWidth={1} // slightly fatter year boundary
     />
   )
@@ -272,7 +272,7 @@ const useHourViewStyles = makeStyles((theme: Theme) => ({
 const getTimelineBoundsLabel = (date: Date) => {
   const time = date.toLocaleTimeString();
   const month = date.getMonth();
-  const day = date.getDay();
+  const day = date.getDate();
   const label = `${month}/${day} @ ${time}`;
   return label;
 }

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -31,7 +31,7 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
     case ZoomLevels.ONE_YEAR:
       return <YearView height={height} domain={domain} timeScale={timeScale} />
     case ZoomLevels.ONE_MONTH:
-      return <MonthView height={height} domain={domain} timeScale={timeScale} showWeekStripes={weekStripes} />
+      return <MonthView height={height} domain={domain} timeScale={timeScale} showWeekStripes={weekStripes === undefined ? true : weekStripes} />
     default:
       return (
         <HourView

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -282,7 +282,7 @@ const getTimelineBoundsLabel = (date: Date) => {
   // +1 because months start at 0
   const month = date.getMonth() + 1;
   const day = date.getDate();
-  const label = `${month}/${day} @ ${time}`;
+  const label = `${month}/${day} ${time}`;
   return label;
 }
 

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -273,7 +273,7 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
 
   // TODO: What should I use as the key? Does it matter?
   const lines = [
-      (<g key={leftBoundDate.getMilliseconds()}>
+      (<g key={1}>
         {/* TODO: maybe add stuff to HourLine like the date or time ago? */}
         <HourLine xPosition={leftBoundPos} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
@@ -281,7 +281,7 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
         </text>
         {/* TODO: add day? Requires logic */}
       </g>),
-      (<g key={rightBoundDate.getMilliseconds()}>
+      (<g key={2}>
         <HourLine xPosition={rightBoundPos} />
         <text className={classes.label} x={rightBoundPos} y={height - 0.5 * monthViewLabelFontSize}>
           {rightBoundDate.toTimeString()}

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -257,6 +257,9 @@ const HourView = ({ height, domain, timeScale }: HourViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useMonthViewStyles(xAxisTheme)
 
+  console.log(domain?.[0]);
+  console.log(domain?.[1]);
+
   // Scale the bounds slightly inside so they don't touch the edges
   const leftBoundMs = domain[0] + SECOND_OFFSET_MS;
   const rightBoundMs = domain[1] - SECOND_OFFSET_MS;

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -241,7 +241,7 @@ const HourLine = ({ xPosition, height }: HourLineProps) => {
       y1={0}
       x2={xPosition}
       y2={height ? height : '80%'}
-      strokeWidth={1} // slightly fatter year boundary
+      strokeWidth={1}
     />
   )
 }

--- a/src/theme/model.ts
+++ b/src/theme/model.ts
@@ -9,8 +9,10 @@ export interface XAxisTheme {
   readonly labelColor: string
   readonly monthLabelFontSize?: number
   readonly yearLabelFontSize?: number
+  readonly hourLabelFontSize?: number
   readonly monthLabelFontWeight?: number | 'normal' | 'bold'
   readonly yearLabelFontWeight?: number | 'normal' | 'bold'
+  readonly hourLabelFontWeight?: number | 'normal' | 'bold'
 }
 
 export interface TooltipTheme {


### PR DESCRIPTION
<img width="1322" alt="Screen Shot 2021-11-04 at 8 48 51 AM" src="https://user-images.githubusercontent.com/66325812/140370571-730a0c0b-cadc-4a58-b345-aa20b86ee35e.png">


Alternative of `middle` text anchor rather than `start` and `end`
![Screen Shot 2021-11-03 at 4 53 51 PM](https://user-images.githubusercontent.com/66325812/140234748-f4d1b34e-8904-4706-8278-a7a0b1e8d27e.png)
