### PR TITLE
Display a message in the case of no events currently being looked at in the timeline

### DIFF
--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -252,7 +252,7 @@ const WeekStripes = ({ monthStart, timeScale }: WeekStripesProps) => {
 interface BoundLineProps {
   xPosition: number
   height?: string
-  classes?: any
+  classes: any
 }
 
 const BoundLine = ({ xPosition, height, classes }: BoundLineProps) => {
@@ -328,7 +328,6 @@ const getEmptyEventsText = (height: number, domain: Domain, timeScale: ScaleLine
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
   return (<g key={3}>
-        <BoundLine xPosition={midPoint} />
         <text className={classes.message} x={midPoint} y={height - 0.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -344,10 +344,10 @@ const getEmptyEventsText = ({ height, domain, timeScale, emptyEventsMessage }) =
   const classes = useEmptyEventsMessageStyles(xAxisTheme)
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
-  return (<g key={1}>
+  return [(<g key={1}>
         <BoundLine xPosition={midPoint} />
         <text className={classes.message} x={midPoint} y={height - 0.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
-      </g>)
+      </g>)]
 }

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -113,6 +113,8 @@ const yearViewLines = ({ height, domain, timeScale, showDecadesOnly = false, cla
   const startYear = new Date(domain[0]).getFullYear()
   const endYear = new Date(domain[1]).getFullYear()
 
+  console.log("startYear is " + startYear)
+  console.log("endYear is " + endYear)
   // -1/+1 to get starting/ending lines, additional +1 because range end is exclusive
   const lines = range(startYear - 1, endYear + 2).map((year) => {
     const yearTimestamp = new Date(year, 0, 1).valueOf()
@@ -292,8 +294,8 @@ const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
   let rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS
 
   if (domain[0] === domain[1]) {
-    leftBoundMs -= TEN_SECOND_OFFSET_MS * 2
-    rightBoundMs += TEN_SECOND_OFFSET_MS * 2
+    leftBoundMs -= TEN_SECOND_OFFSET_MS * 10
+    rightBoundMs += TEN_SECOND_OFFSET_MS * 10
   }
   // Scale the bounds slightly inside so they don't touch the edges
 
@@ -327,7 +329,7 @@ const getEmptyEventsText = (height: number, domain: Domain, timeScale: ScaleLine
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
   return (<g key={3}>
-        <text className={classes.message} x={midPoint} y={height - 2 * defaultEmptyEventsMessageFontSize}>
+        <text className={classes.message} x={midPoint} y={height - 2.25 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -339,7 +339,7 @@ const useEmptyEventsMessageStyles = makeStyles((theme: Theme) => ({
   }),
 }))
 
-const getEmptyEventsText = (height, domain, timeScale, emptyEventsMessage) => {
+const getEmptyEventsText = (height: number, domain, timeScale, emptyEventsMessage) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useEmptyEventsMessageStyles(xAxisTheme)
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -321,13 +321,13 @@ const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
   return lines
 }
 
-const defaultEmptyEventsMessageFontSize = 25
+const defaultEmptyEventsMessageFontSize = 30
 
 const getEmptyEventsText = (height: number, domain: Domain, timeScale: ScaleLinear<number, number>, emptyEventsMessage: string, classes: any) => {
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
   return (<g key={3}>
-        <text className={classes.message} x={midPoint} y={height - 2.5 * defaultEmptyEventsMessageFontSize}>
+        <text className={classes.message} x={midPoint} y={height - 2 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -240,11 +240,11 @@ const WeekStripes = ({ monthStart, timeScale }: WeekStripesProps) => {
 interface BoundLineProps {
   xPosition: number
   height?: string
+  classes?: any
 }
 
-const BoundLine = ({ xPosition, height }: BoundLineProps) => {
+const BoundLine = ({ xPosition, height, classes }: BoundLineProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
-  const classes = useHourViewStyles(xAxisTheme)
   return (
     <line
       className={classes.line}
@@ -309,13 +309,13 @@ const boundViewLines = ({ height, domain, timeScale }: ViewProps) => {
 
   const lines = [
       (<g key={1}>
-        <BoundLine xPosition={leftBoundPos} />
+        <BoundLine xPosition={leftBoundPos} classes={classes} />
         <text className={classes.label} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {leftBoundLabel}
         </text>
       </g>),
       (<g key={2}>
-        <BoundLine xPosition={rightBoundPos} />
+        <BoundLine xPosition={rightBoundPos} classes={classes} />
         <text className={classes.label} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {rightBoundLabel}
         </text>

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -31,18 +31,18 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
   let svgGroups = []
   switch (smallerZoomScale) {
     case ZoomLevels.TEN_YEARS:
-      svgGroups.push(yearViewLines({height:height, domain:domain, timeScale:timeScale, showDecadesOnly:true}))
+      svgGroups.push(...yearViewLines({height:height, domain:domain, timeScale:timeScale, showDecadesOnly:true}))
       break
     case ZoomLevels.ONE_YEAR:
-      svgGroups.push(yearViewLines({height:height, domain:domain, timeScale:timeScale}))
+      svgGroups.push(...yearViewLines({height:height, domain:domain, timeScale:timeScale}))
       break
     default:
-      svgGroups.push(monthViewLines({height:height, domain:domain, timeScale:timeScale, showWeekStripes:weekStripes === undefined ? true : weekStripes}))
+      svgGroups.push(...monthViewLines({height:height, domain:domain, timeScale:timeScale, showWeekStripes:weekStripes === undefined ? true : weekStripes}))
       break
   }
   // If there are no events to display, add some text that says so
   if (noEventsInDomain && emptyEventsMessage) {
-    svgGroups.push(getEmptyEventsText({height, domain, timeScale, emptyEventsMessage}))
+    svgGroups.push(getEmptyEventsText(height, domain, timeScale, emptyEventsMessage))
   }
 
   if (showBounds) {
@@ -339,7 +339,7 @@ const useEmptyEventsMessageStyles = makeStyles((theme: Theme) => ({
   }),
 }))
 
-const getEmptyEventsText = ({ height, domain, timeScale, emptyEventsMessage }) => {
+const getEmptyEventsText = (height, domain, timeScale, emptyEventsMessage) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useEmptyEventsMessageStyles(xAxisTheme)
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -32,23 +32,26 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
   switch (smallerZoomScale) {
     case ZoomLevels.TEN_YEARS:
       svgGroups = <YearView height={height} domain={domain} timeScale={timeScale} showDecadesOnly={true} />
+      break
     case ZoomLevels.ONE_YEAR:
       svgGroups = <YearView height={height} domain={domain} timeScale={timeScale} />
+      break
     default:
       svgGroups = <MonthView height={height} domain={domain} timeScale={timeScale} showWeekStripes={weekStripes === undefined ? true : weekStripes} />
+      break
   }
   // If there are no events to display, add some text that says so
   if (noEventsInDomain && emptyEventsMessage) {
-    svgGroups.push(getEmptyEventsText({height, domain, timeScale, emptyEventsMessage}));
+    svgGroups.push(getEmptyEventsText({height, domain, timeScale, emptyEventsMessage}))
   }
 
   if (showBounds) {
     // Add in boundary lines in addition to other lines
-    const boundLines = boundViewLines({height, domain, timeScale});
-    svgGroups.push(...boundLines);
+    const boundLines = boundViewLines({height, domain, timeScale})
+    svgGroups.push(...boundLines)
   }
 
-  return (<g>{svgGroups}</g>);
+  return (<g>{svgGroups}</g>)
 }
 
 /* ·················································································································· */
@@ -254,7 +257,7 @@ const BoundLine = ({ xPosition, height }: BoundLineProps) => {
   )
 }
 
-const TEN_SECOND_OFFSET_MS = 10000;
+const TEN_SECOND_OFFSET_MS = 10000
 interface ViewProps {
   height: number
   domain: [number, number]
@@ -277,29 +280,29 @@ const useHourViewStyles = makeStyles((theme: Theme) => ({
 }))
 
 const getTimelineBoundsLabel = (date: Date) => {
-  const time = date.toLocaleTimeString();
+  const time = date.toLocaleTimeString()
   // +1 because months start at 0
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const label = `${month}/${day} ${time}`;
-  return label;
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const label = `${month}/${day} ${time}`
+  return label
 }
 
 const boundViewLines = ({ height, domain, timeScale }: ViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useHourViewStyles(xAxisTheme)
 
-  let leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS;
-  let rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS;
+  let leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS
+  let rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS
 
   if (domain[0] === domain[1]) {
-    leftBoundMs -= TEN_SECOND_OFFSET_MS * 2;
-    rightBoundMs += TEN_SECOND_OFFSET_MS * 2;
+    leftBoundMs -= TEN_SECOND_OFFSET_MS * 2
+    rightBoundMs += TEN_SECOND_OFFSET_MS * 2
   }
   // Scale the bounds slightly inside so they don't touch the edges
 
-  const leftBoundLabel = getTimelineBoundsLabel(new Date(leftBoundMs));
-  const rightBoundLabel = getTimelineBoundsLabel(new Date(rightBoundMs));
+  const leftBoundLabel = getTimelineBoundsLabel(new Date(leftBoundMs))
+  const rightBoundLabel = getTimelineBoundsLabel(new Date(rightBoundMs))
 
   const leftBoundPos = timeScale(leftBoundMs)!
   const rightBoundPos = timeScale(rightBoundMs)!
@@ -317,12 +320,12 @@ const boundViewLines = ({ height, domain, timeScale }: ViewProps) => {
           {rightBoundLabel}
         </text>
       </g>)
-  ];
+  ]
 
-  return lines;
+  return lines
 }
 
-const defaultEmptyEventsMessageFontSize = 16;
+const defaultEmptyEventsMessageFontSize = 16
 
 const useEmptyEventsMessageStyles = makeStyles((theme: Theme) => ({
   message: (xAxisTheme: XAxisTheme) => ({
@@ -346,5 +349,5 @@ const getEmptyEventsText = ({ height, domain, timeScale, emptyEventsMessage }) =
         <text className={classes.message} x={midPoint} y={height - 0.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
-      </g>);
+      </g>)
 }

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -321,13 +321,13 @@ const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
   return lines
 }
 
-const defaultEmptyEventsMessageFontSize = 20
+const defaultEmptyEventsMessageFontSize = 25
 
 const getEmptyEventsText = (height: number, domain: Domain, timeScale: ScaleLinear<number, number>, emptyEventsMessage: string, classes: any) => {
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
   return (<g key={3}>
-        <text className={classes.message} x={midPoint} y={height - 1.5 * defaultEmptyEventsMessageFontSize}>
+        <text className={classes.message} x={midPoint} y={height - 2.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -339,7 +339,7 @@ const useEmptyEventsMessageStyles = makeStyles((theme: Theme) => ({
   }),
 }))
 
-const getEmptyEventsText = (height: number, domain, timeScale, emptyEventsMessage) => {
+const getEmptyEventsText = (height: number, domain: Domain, timeScale: ScaleLinear<number, number>, emptyEventsMessage: string) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useEmptyEventsMessageStyles(xAxisTheme)
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -48,7 +48,7 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
     svgGroups.push(...boundLines);
   }
 
-  return svgGroups;
+  return (<g>{svgGroups}</g>);
 }
 
 /* ·················································································································· */

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -31,13 +31,13 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
   let svgGroups = []
   switch (smallerZoomScale) {
     case ZoomLevels.TEN_YEARS:
-      svgGroups = <YearView height={height} domain={domain} timeScale={timeScale} showDecadesOnly={true} />
+      svgGroups.push(yearViewLines({height:height, domain:domain, timeScale:timeScale, showDecadesOnly:true}))
       break
     case ZoomLevels.ONE_YEAR:
-      svgGroups = <YearView height={height} domain={domain} timeScale={timeScale} />
+      svgGroups.push(yearViewLines({height:height, domain:domain, timeScale:timeScale}))
       break
     default:
-      svgGroups = <MonthView height={height} domain={domain} timeScale={timeScale} showWeekStripes={weekStripes === undefined ? true : weekStripes} />
+      svgGroups.push(monthViewLines({height:height, domain:domain, timeScale:timeScale, showWeekStripes:weekStripes === undefined ? true : weekStripes}))
       break
   }
   // If there are no events to display, add some text that says so
@@ -74,7 +74,7 @@ interface YearViewProps extends Omit<Props, 'smallerZoomScale'> {
   showDecadesOnly?: boolean
 }
 
-const YearView = ({ height, domain, timeScale, showDecadesOnly = false }: YearViewProps) => {
+const yearViewLines = ({ height, domain, timeScale, showDecadesOnly = false }: YearViewProps) => {
   const xAxisTheme: XAxisTheme = useTimelineTheme().xAxis
   const classes = useYearViewStyles(xAxisTheme)
 
@@ -108,7 +108,7 @@ const YearView = ({ height, domain, timeScale, showDecadesOnly = false }: YearVi
     )
   })
 
-  return <g>{lines}</g>
+  return lines
 }
 
 /* ·················································································································· */
@@ -135,7 +135,7 @@ interface MonthViewProps extends Omit<Props, 'smallerZoomScale'> {
   showWeekStripes?: boolean
 }
 
-const MonthView = ({ height, domain, timeScale, showWeekStripes = false }: MonthViewProps) => {
+const monthViewLines = ({ height, domain, timeScale, showWeekStripes = false }: MonthViewProps) => {
   const xAxisTheme = useTimelineTheme().xAxis
   const classes = useMonthViewStyles(xAxisTheme)
 
@@ -179,7 +179,7 @@ const MonthView = ({ height, domain, timeScale, showWeekStripes = false }: Month
     )
   })
 
-  return <g>{lines}</g>
+  return lines
 }
 
 interface MonthLineProps {
@@ -230,7 +230,7 @@ const WeekStripes = ({ monthStart, timeScale }: WeekStripesProps) => {
     }
   })
 
-  return <g>{lines}</g>
+  return lines
 }
 
 /* ·················································································································· */
@@ -344,10 +344,10 @@ const getEmptyEventsText = ({ height, domain, timeScale, emptyEventsMessage }) =
   const classes = useEmptyEventsMessageStyles(xAxisTheme)
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
-  return [(<g key={1}>
+  return (<g key={3}>
         <BoundLine xPosition={midPoint} />
         <text className={classes.message} x={midPoint} y={height - 0.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
-      </g>)]
+      </g>)
 }

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -59,7 +59,7 @@ const useGridStyles = makeStyles((theme: Theme) => ({
     fill: xAxisTheme.labelColor,
     opacity: 1,
     fontFamily: theme.typography.caption.fontFamily,
-    fontSize: xAxisTheme.yearLabelFontSize ? xAxisTheme.yearLabelFontSize : defaultEmptyEventsMessageFontSize,
+    fontSize: defaultEmptyEventsMessageFontSize,
     fontWeight: xAxisTheme.yearLabelFontWeight ? xAxisTheme.yearLabelFontWeight : 'bold',
     textAnchor: 'middle',
     cursor: 'default',

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -84,6 +84,7 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
   }
   // If there are no events to display, add some text that says so
   if (noEventsInDomain && emptyEventsMessage) {
+    console.log("pushing empty text events")
     svgGroups.push(getEmptyEventsText(height, domain, timeScale, emptyEventsMessage, styles))
   }
 
@@ -288,7 +289,6 @@ const getTimelineBoundsLabel = (date: Date) => {
 }
 
 const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
-  console.log(classes)
   let leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS
   let rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS
 

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -47,7 +47,9 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
 
   if (showBounds) {
     // Add in boundary lines in addition to other lines
-    svgGroups.push(...boundViewLines({height, domain, timeScale}))
+    const xAxisTheme = useTimelineTheme().xAxis
+    const classes = useMonthViewStyles(xAxisTheme)
+    svgGroups.push(...boundViewLines({height, domain, timeScale, classes}))
   }
 
   return (<g>{svgGroups}</g>)
@@ -260,6 +262,7 @@ interface ViewProps {
   height: number
   domain: [number, number]
   timeScale: ScaleLinear<number, number>
+  classes: any
 }
 
 const defaultHourViewLabelFontSize = 10
@@ -286,9 +289,7 @@ const getTimelineBoundsLabel = (date: Date) => {
   return label
 }
 
-const boundViewLines = ({ height, domain, timeScale }: ViewProps) => {
-  const xAxisTheme = useTimelineTheme().xAxis
-  const classes = useHourViewStyles(xAxisTheme)
+const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
 
   let leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS
   let rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -47,8 +47,7 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
 
   if (showBounds) {
     // Add in boundary lines in addition to other lines
-    const boundLines = boundViewLines({height, domain, timeScale})
-    svgGroups.push(...boundLines)
+    svgGroups.push(...boundViewLines({height, domain, timeScale}))
   }
 
   return (<g>{svgGroups}</g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -57,7 +57,7 @@ const useGridStyles = makeStyles((theme: Theme) => ({
   }),
   message: (xAxisTheme: XAxisTheme) => ({
     fill: xAxisTheme.labelColor,
-    opacity: 0.75,
+    opacity: 1,
     fontFamily: theme.typography.caption.fontFamily,
     fontSize: xAxisTheme.yearLabelFontSize ? xAxisTheme.yearLabelFontSize : defaultEmptyEventsMessageFontSize,
     fontWeight: xAxisTheme.yearLabelFontWeight ? xAxisTheme.yearLabelFontWeight : 'bold',
@@ -84,7 +84,6 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
   }
   // If there are no events to display, add some text that says so
   if (noEventsInDomain && emptyEventsMessage) {
-    console.log("pushing empty text events")
     svgGroups.push(getEmptyEventsText(height, domain, timeScale, emptyEventsMessage, styles))
   }
 
@@ -322,13 +321,13 @@ const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
   return lines
 }
 
-const defaultEmptyEventsMessageFontSize = 16
+const defaultEmptyEventsMessageFontSize = 20
 
 const getEmptyEventsText = (height: number, domain: Domain, timeScale: ScaleLinear<number, number>, emptyEventsMessage: string, classes: any) => {
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
   return (<g key={3}>
-        <text className={classes.message} x={midPoint} y={height - 0.5 * defaultEmptyEventsMessageFontSize}>
+        <text className={classes.message} x={midPoint} y={height - 1.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -89,7 +89,7 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
 
   if (showBounds) {
     // Add in boundary lines in addition to other lines
-    svgGroups.push(...boundViewLines({height, domain, timeScale, styles}))
+    svgGroups.push(...boundViewLines({height, domain, timeScale, classes:styles}))
   }
 
   return (<g>{svgGroups}</g>)
@@ -273,7 +273,7 @@ interface ViewProps {
   height: number
   domain: [number, number]
   timeScale: ScaleLinear<number, number>
-  styles: any
+  classes: any
 }
 
 const defaultHourViewLabelFontSize = 10
@@ -287,7 +287,8 @@ const getTimelineBoundsLabel = (date: Date) => {
   return label
 }
 
-const boundViewLines = ({ height, domain, timeScale, styles }: ViewProps) => {
+const boundViewLines = ({ height, domain, timeScale, classes }: ViewProps) => {
+  console.log(classes)
   let leftBoundMs = domain[0] + TEN_SECOND_OFFSET_MS
   let rightBoundMs = domain[1] - TEN_SECOND_OFFSET_MS
 
@@ -305,14 +306,14 @@ const boundViewLines = ({ height, domain, timeScale, styles }: ViewProps) => {
 
   const lines = [
       (<g key={1}>
-        <BoundLine xPosition={leftBoundPos} classes={styles} />
-        <text className={styles.boundsLabel} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
+        <BoundLine xPosition={leftBoundPos} classes={classes} />
+        <text className={classes.boundsLabel} x={leftBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {leftBoundLabel}
         </text>
       </g>),
       (<g key={2}>
-        <BoundLine xPosition={rightBoundPos} classes={styles} />
-        <text className={styles.boundsLabel} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
+        <BoundLine xPosition={rightBoundPos} classes={classes} />
+        <text className={classes.boundsLabel} x={rightBoundPos} y={height - 0.5 * defaultHourViewLabelFontSize}>
           {rightBoundLabel}
         </text>
       </g>)

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -113,8 +113,6 @@ const yearViewLines = ({ height, domain, timeScale, showDecadesOnly = false, cla
   const startYear = new Date(domain[0]).getFullYear()
   const endYear = new Date(domain[1]).getFullYear()
 
-  console.log("startYear is " + startYear)
-  console.log("endYear is " + endYear)
   // -1/+1 to get starting/ending lines, additional +1 because range end is exclusive
   const lines = range(startYear - 1, endYear + 2).map((year) => {
     const yearTimestamp = new Date(year, 0, 1).valueOf()

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -244,7 +244,6 @@ interface BoundLineProps {
 }
 
 const BoundLine = ({ xPosition, height, classes }: BoundLineProps) => {
-  const xAxisTheme = useTimelineTheme().xAxis
   return (
     <line
       className={classes.line}

--- a/src/GridLines.tsx
+++ b/src/GridLines.tsx
@@ -166,7 +166,7 @@ const monthViewLines = ({ height, domain, timeScale, showWeekStripes = false }: 
     const isLast = index === monthNumbers.length - 1
     return (
       <g key={rawMonth}>
-        {showWeekStripes && <WeekStripes monthStart={monthTimestamp} timeScale={timeScale} />}
+        {showWeekStripes && WeekStripes({monthStart:monthTimestamp, timeScale:timeScale})}
         <MonthLine x={x} month={month} />
         <text className={classes.label} x={xMidMonth} y={height - 1.5 * monthViewLabelFontSize}>
           {monthName}

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -150,6 +150,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
     )
 
     const isNoEventSelected = eventsInsideDomain.filter((e) => e.isSelected).length === 0
+    console.log(eventsInsideDomain)
     const noEventsInDomain = eventsInsideDomain.length === 0
 
     const isZoomInPossible = smallerZoomScale !== 'minimum'

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -42,7 +42,8 @@ export interface TimelineProps<EID extends string, LID extends string, E extends
   cursorColor?: string
   tooltipArrow?: boolean
   animationDuration?: number
-  emptyMessage?: string
+  showBounds?: boolean
+  emptyEventsMessage?: string
 }
 
 type Animation =
@@ -87,6 +88,8 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
   cursorColor,
   tooltipArrow = true,
   animationDuration = 1000,
+  showBounds = true,
+  emptyEventsMessage = 'No events in selected time range',
 }: TimelineProps<EID, LID, E>) => {
   {
     const maxDomain = customRange ?? calcMaxDomain(events)
@@ -147,7 +150,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
     )
 
     const isNoEventSelected = eventsInsideDomain.filter((e) => e.isSelected).length === 0
-      console.log(eventsInsideDomain);
+    const noEventsInDomain = eventsInsideDomain.length === 0
 
     const isZoomInPossible = smallerZoomScale !== 'minimum'
     const isZoomOutPossible = currentDomainWidth < maxDomainWidth
@@ -289,6 +292,9 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
                         smallerZoomScale={smallerZoomScale}
                         timeScale={timeScale}
                         weekStripes={weekStripes}
+                        showBounds={showBounds}
+                        noEventsInDomain={noEventsInDomain}
+                        emptyEventsMessage={emptyEventsMessage}
                       />
                       {showMarks && (
                         <>

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -147,8 +147,8 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
     )
 
     const isNoEventSelected = eventsInsideDomain.filter((e) => e.isSelected).length === 0
-      console.log(isNoEventSelected);
-      
+      console.log(eventsInsideDomain);
+
     const isZoomInPossible = smallerZoomScale !== 'minimum'
     const isZoomOutPossible = currentDomainWidth < maxDomainWidth
     const isAnimationInProgress = animation !== 'none'

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -42,6 +42,7 @@ export interface TimelineProps<EID extends string, LID extends string, E extends
   cursorColor?: string
   tooltipArrow?: boolean
   animationDuration?: number
+  emptyMessage?: string
 }
 
 type Animation =
@@ -146,7 +147,8 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
     )
 
     const isNoEventSelected = eventsInsideDomain.filter((e) => e.isSelected).length === 0
-
+      console.log(isNoEventSelected);
+      
     const isZoomInPossible = smallerZoomScale !== 'minimum'
     const isZoomOutPossible = currentDomainWidth < maxDomainWidth
     const isAnimationInProgress = animation !== 'none'

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -60,9 +60,13 @@ const defaultTimeMax = Date.now()
 export const calcMaxDomain = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>(
   events: ReadonlyArray<E>
 ): Domain => {
-  const timeMin = Math.min(...events.map((e) => e.startTimeMillis)) 
+  if (events.length === 0) {
+    return [defaultTimeMin, defaultTimeMax]
+  }
+
+  const timeMin = Math.min(...events.map((e) => e.startTimeMillis))
   const timeMax = Math.max(...events.map((e) => (e.endTimeMillis === undefined ? e.startTimeMillis : e.endTimeMillis)))
-  return [timeMin ? timeMin : defaultTimeMin, timeMax ? timeMax : defaultTimeMax]
+  return [timeMin, timeMax]
 }
 
 export const Timeline = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>({

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -54,12 +54,15 @@ type Animation =
       toDomain: Domain
     }>
 
+const defaultTimeMin = Date.now() - 100000
+const defaultTimeMax = Date.now()
+
 export const calcMaxDomain = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>(
   events: ReadonlyArray<E>
 ): Domain => {
-  const timeMin = Math.min(...events.map((e) => e.startTimeMillis))
+  const timeMin = Math.min(...events.map((e) => e.startTimeMillis)) 
   const timeMax = Math.max(...events.map((e) => (e.endTimeMillis === undefined ? e.startTimeMillis : e.endTimeMillis)))
-  return [timeMin || NaN, timeMax || NaN]
+  return [timeMin ? timeMin : defaultTimeMin, timeMax ? timeMax : defaultTimeMax]
 }
 
 export const Timeline = <EID extends string, LID extends string, E extends TimelineEvent<EID, LID>>({
@@ -150,8 +153,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
     )
 
     const isNoEventSelected = eventsInsideDomain.filter((e) => e.isSelected).length === 0
-    console.log(eventsInsideDomain)
-    const noEventsInDomain = eventsInsideDomain.length === 0
+    const noEventsInDomain = events.length === 0 ? true : eventsInsideDomain.length === 0
 
     const isZoomInPossible = smallerZoomScale !== 'minimum'
     const isZoomOutPossible = currentDomainWidth < maxDomainWidth


### PR DESCRIPTION
<img width="595" alt="Screen Shot 2021-11-07 at 12 02 56 AM" src="https://user-images.githubusercontent.com/66325812/140635752-4d7fd05b-5c6c-47d7-aafb-f6ffa2a77e35.png">

Also refactored some of the styling stuff to make things more organized and have less code duplication

this can be reviewed after https://github.com/lyft/react-svg-timeline/pull/22
and https://github.com/lyft/react-svg-timeline/pull/21 and  https://github.com/lyft/react-svg-timeline/pull/23 are merged