### PR TITLE
support adding links to event marks

### DIFF
--- a/src/Marks.tsx
+++ b/src/Marks.tsx
@@ -176,12 +176,18 @@ const InteractiveEventMark = <EID extends string, LID extends string, E extends 
   return (
     <g
       pointerEvents={'bounding-box'}
-      cursor={'default'}
+      cursor={event.link ? 'pointer' : 'default'}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onClick={onMouseClick}
     >
-      <g ref={triggerRef}>{children}</g>
+      {event.link ? (
+        <a href={event.link} target="_blank" rel="noreferrer noopener">
+          <g ref={triggerRef}>{children}</g>
+        </a>
+      ) : (
+        <g ref={triggerRef}>{children}</g>
+      )}
       {event.tooltip ? (
         <EventTooltip
           type={tooltipType}

--- a/src/Marks.tsx
+++ b/src/Marks.tsx
@@ -176,13 +176,13 @@ const InteractiveEventMark = <EID extends string, LID extends string, E extends 
   return (
     <g
       pointerEvents={'bounding-box'}
-      cursor={event.link ? 'pointer' : 'default'}
+      cursor={event.URLlink ? 'pointer' : 'default'}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onClick={onMouseClick}
     >
-      {event.link ? (
-        <a href={event.link} target="_blank" rel="noreferrer noopener">
+      {event.URLlink ? (
+        <a href={event.URLlink} target="_blank" rel="noreferrer noopener">
           <g ref={triggerRef}>{children}</g>
         </a>
       ) : (

--- a/src/model.tsx
+++ b/src/model.tsx
@@ -9,6 +9,7 @@ export interface TimelineEvent<EID extends string, LID extends string> {
   tooltip?: string
   isSelected?: boolean
   isPinned?: boolean
+  link?: string
 }
 
 export interface TimelineLane<LID extends string> {

--- a/src/model.tsx
+++ b/src/model.tsx
@@ -9,7 +9,7 @@ export interface TimelineEvent<EID extends string, LID extends string> {
   tooltip?: string
   isSelected?: boolean
   isPinned?: boolean
-  link?: string
+  URLlink?: string
 }
 
 export interface TimelineLane<LID extends string> {


### PR DESCRIPTION
PR adds an optional `URLlink` prop to the TimelineEvent interface so that event marks can link out to an external site.


![demo](https://user-images.githubusercontent.com/39421794/140999488-18934fa8-ac71-40a2-b0b5-cecad702013e.gif)

cursor if event has a url link
<img width="275" alt="Screen Shot 2021-11-09 at 3 19 44 PM" src="https://user-images.githubusercontent.com/39421794/140998757-d6b30cd1-5105-41fe-8310-1da492f1dfb6.png">

cursor if event doesn't have url link
<img width="329" alt="Screen Shot 2021-11-09 at 3 19 26 PM" src="https://user-images.githubusercontent.com/39421794/140998788-1b07e5e0-43c2-4ab1-804a-4fe06aba2311.png">