### PR TITLE
In the case of no events in the domain, show a message denoting such

### DIFF
--- a/src/EmptyEventsText.tsx
+++ b/src/EmptyEventsText.tsx
@@ -25,7 +25,7 @@ interface EmptyEventsProps {
     emptyEventsMessage: string,
 }
 
-const defaultEmptyEventsMessageFontSize = 24
+const defaultEmptyEventsMessageFontSize = 20
 
 export const EmptyEventsText = ({height, domain, timeScale, emptyEventsMessage}: EmptyEventsProps) => {
   // TODO(smonero): remove this boilerplate style code everywhere
@@ -35,7 +35,7 @@ export const EmptyEventsText = ({height, domain, timeScale, emptyEventsMessage}:
   const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
 
   return (<g key={3}>
-        <text className={styles.message} x={midPoint} y={height - 2.25 * defaultEmptyEventsMessageFontSize}>
+        <text className={styles.message} x={midPoint} y={height - 2.5 * defaultEmptyEventsMessageFontSize}>
           {emptyEventsMessage}
         </text>
       </g>)

--- a/src/EmptyEventsText.tsx
+++ b/src/EmptyEventsText.tsx
@@ -25,7 +25,7 @@ interface EmptyEventsProps {
     emptyEventsMessage: string,
 }
 
-const defaultEmptyEventsMessageFontSize = 30
+const defaultEmptyEventsMessageFontSize = 24
 
 export const EmptyEventsText = ({height, domain, timeScale, emptyEventsMessage}: EmptyEventsProps) => {
   // TODO(smonero): remove this boilerplate style code everywhere

--- a/src/EmptyEventsText.tsx
+++ b/src/EmptyEventsText.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-import { ScaleLinear } from 'd3-scale'
-import { Domain } from './model'
 import { useTimelineTheme } from '../theme'
 import { XAxisTheme } from '../theme/model'
 import makeStyles from '@material-ui/core/styles/makeStyles'

--- a/src/EmptyEventsText.tsx
+++ b/src/EmptyEventsText.tsx
@@ -3,6 +3,8 @@ import { useTimelineTheme } from './theme'
 import { XAxisTheme } from './theme/model'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import { Theme } from '@material-ui/core'
+import { Domain } from './model'
+import { ScaleLinear } from 'd3-scale'
 
 const messageStyle = makeStyles((theme: Theme) => ({
     message: (xAxisTheme: XAxisTheme) => ({
@@ -16,9 +18,16 @@ const messageStyle = makeStyles((theme: Theme) => ({
     }),
   }))
 
+interface EmptyEventsProps {
+    height: number,
+    domain: Domain,
+    timeScale: ScaleLinear<number, number>,
+    emptyEventsMessage: string,
+}
+
 const defaultEmptyEventsMessageFontSize = 30
 
-export const EmptyEventsText = ({height, domain, timeScale, emptyEventsMessage}) => {
+export const EmptyEventsText = ({height, domain, timeScale, emptyEventsMessage}: EmptyEventsProps) => {
   // TODO(smonero): remove this boilerplate style code everywhere
   const xAxisTheme: XAxisTheme = useTimelineTheme().xAxis
   const styles = messageStyle(xAxisTheme)

--- a/src/EmptyEventsText.tsx
+++ b/src/EmptyEventsText.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { ScaleLinear } from 'd3-scale'
+import { Domain } from './model'
+import { useTimelineTheme } from '../theme'
+import { XAxisTheme } from '../theme/model'
+import makeStyles from '@material-ui/core/styles/makeStyles'
+import { Theme } from '@material-ui/core'
+
+const messageStyle = makeStyles((theme: Theme) => ({
+    message: (xAxisTheme: XAxisTheme) => ({
+      fill: xAxisTheme.labelColor,
+      opacity: 1,
+      fontFamily: theme.typography.caption.fontFamily,
+      fontSize: defaultEmptyEventsMessageFontSize,
+      fontWeight: xAxisTheme.yearLabelFontWeight ? xAxisTheme.yearLabelFontWeight : 'bold',
+      textAnchor: 'middle',
+      cursor: 'default',
+    }),
+  }))
+
+const defaultEmptyEventsMessageFontSize = 30
+
+export const EmptyEventsText = ({height, domain, timeScale, emptyEventsMessage}) => {
+  // TODO(smonero): remove this boilerplate style code everywhere
+  const xAxisTheme: XAxisTheme = useTimelineTheme().xAxis
+  const styles = messageStyle(xAxisTheme)
+
+  const midPoint = (timeScale(domain[0])! + timeScale(domain[1])!) / 2
+
+  return (<g key={3}>
+        <text className={styles.message} x={midPoint} y={height - 2.25 * defaultEmptyEventsMessageFontSize}>
+          {emptyEventsMessage}
+        </text>
+      </g>)
+}

--- a/src/EmptyEventsText.tsx
+++ b/src/EmptyEventsText.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { useTimelineTheme } from '../theme'
-import { XAxisTheme } from '../theme/model'
+import { useTimelineTheme } from './theme'
+import { XAxisTheme } from './theme/model'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import { Theme } from '@material-ui/core'
 

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -15,6 +15,7 @@ import { EventClusters } from './EventClusters'
 import { TimelineTheme } from './theme'
 import { TimelineThemeProvider } from './theme/TimelineThemeProvider'
 import { useZoomLevels } from './hooks/useZoomLevels'
+import { EmptyEventsText } from './EmptyEventsText'
 
 export interface TimelineProps<EID extends string, LID extends string, E extends TimelineEvent<EID, LID>> {
   width: number
@@ -153,6 +154,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
     )
 
     const isNoEventSelected = eventsInsideDomain.filter((e) => e.isSelected).length === 0
+    const noEventsInDomain = eventsInsideDomain.length === 0
 
     const isZoomInPossible = smallerZoomScale !== 'minimum'
     const isZoomOutPossible = currentDomainWidth < maxDomainWidth
@@ -295,6 +297,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
                         timeScale={timeScale}
                         weekStripes={weekStripes}
                       />
+                      {noEventsInDomain && (<EmptyEventsText height={height} domain={domain} timeScale={timeScale} emptyEventsMessage={"No events in selected time range"}/>)}
                       {showMarks && (
                         <>
                           <EventClusters


### PR DESCRIPTION
<img width="522" alt="Screen Shot 2021-11-09 at 12 19 51 PM" src="https://user-images.githubusercontent.com/66325812/140998776-6d295ef6-5383-43ca-9ec3-c1b9eda58762.png">

alternative option of text: "no events have occurred for the time range selected"