### PR TITLE
fix the half days for the "DAY" zoom level being too close together

### DIFF
--- a/src/layers/GridLines.tsx
+++ b/src/layers/GridLines.tsx
@@ -35,7 +35,7 @@ export const GridLines = ({ height, domain, smallerZoomScale, timeScale, weekStr
     case ZoomLevels.ONE_WEEK:
       return <HoursView height={height} domain={domain} timeScale={timeScale} doubles={true} ones={false} halves={false} quarters={false} eights={false} />
     case ZoomLevels.ONE_DAY:
-      return <HoursView height={height} domain={domain} timeScale={timeScale} doubles={true} ones={true} halves={true} quarters={false} eights={false} />
+      return <HoursView height={height} domain={domain} timeScale={timeScale} doubles={true} ones={true} halves={false} quarters={false} eights={false} />
     case ZoomLevels.TWELVE_HOURS:
       return <HoursView height={height} domain={domain} timeScale={timeScale} doubles={true} ones={true} halves={true} quarters={true} eights={true} />
     case ZoomLevels.SIX_HOURS:


### PR DESCRIPTION
Last PR I didn't realize I put them so close together. They look better spaced out without the half days.
now:
<img width="351" alt="Screen Shot 2021-12-13 at 9 55 56 AM" src="https://user-images.githubusercontent.com/66325812/145865409-3827fcbc-1c88-47e3-a2b2-8c5b8d29bb61.png">
before:
<img width="250" alt="Screen Shot 2021-12-13 at 9 55 27 AM" src="https://user-images.githubusercontent.com/66325812/145865410-3a811f41-9092-4bc7-82f0-6ef79de56770.png">
.